### PR TITLE
Call WithTracing on RootContext only on configuration

### DIFF
--- a/Backend/Actors/VehicleActor.cs
+++ b/Backend/Actors/VehicleActor.cs
@@ -16,7 +16,7 @@ public class VehicleActor : VehicleActorBase
     {
         _mapGrid = mapGrid;
         _positionsHistory = new VehiclePositionHistory();
-        _senderContext = Context.System.Root.WithTracing();
+        _senderContext = Context.System.Root;
     }
 
     public override async Task OnPosition(Position position)

--- a/Backend/Api/OrganizationApi.cs
+++ b/Backend/Api/OrganizationApi.cs
@@ -29,7 +29,6 @@ public static class OrganizationApi
 
                 var geofences = await organizationActorClient.GetGeofences(
                     new GetGeofencesRequest {OrgId = id},
-                    cluster.System.Root.WithTracing(),
                     CancellationToken.None
                 );
 

--- a/Backend/Api/TrailApi.cs
+++ b/Backend/Api/TrailApi.cs
@@ -14,7 +14,6 @@ public static class TrailApi
                 .GetVehicleActor(vehicleId)
                 .GetPositionsHistory(
                     new GetPositionsHistoryRequest(), 
-                    cluster.System.Root.WithTracing(),
                     CancellationToken.None);
 
             if (positionsHistory == null) return Results.StatusCode((int)HttpStatusCode.ServiceUnavailable); // timeout

--- a/Backend/Hubs/EventsHub.cs
+++ b/Backend/Hubs/EventsHub.cs
@@ -22,7 +22,7 @@ public class EventsHub : Hub
     public EventsHub(Cluster cluster, IHubContext<EventsHub> eventsHubContext, ILogger<EventsHub> logger, MapGrid mapGrid)
     {
         _cluster = cluster;
-        _senderContext = cluster.System.Root.WithTracing();
+        _senderContext = cluster.System.Root;
         _logger = logger;
         _mapGrid = mapGrid;
 

--- a/Backend/MQTT/Ingress.cs
+++ b/Backend/MQTT/Ingress.cs
@@ -15,7 +15,7 @@ public class MqttIngress : IHostedService
     {
         _configuration = configuration;
         _cluster = cluster;
-        _senderContext = _cluster.System.Root.WithTracing();
+        _senderContext = _cluster.System.Root;
         _loggerFactory = loggerFactory;
     }
 

--- a/Backend/ProtoActorExtensions.cs
+++ b/Backend/ProtoActorExtensions.cs
@@ -33,7 +33,8 @@ public static class ProtoActorExtensions
                 .Setup()
                 .WithMetrics()
                 .WithDeadLetterThrottleCount(3)
-                .WithDeadLetterThrottleInterval(TimeSpan.FromSeconds(1));
+                .WithDeadLetterThrottleInterval(TimeSpan.FromSeconds(1))
+                .WithConfigureRootContext(context => context.WithTracing());
 
             if (config.GetValue<bool>("ProtoActor:DeveloperLogging"))
             {


### PR DESCRIPTION
`WithTracing` should only be called on Cluster configuration within `.WithConfigureRootContext` method. Calling `WithTracing` on each API call etc. results in a multiple `OpenTelemetrySenderMiddleware` added to RootContext when usually only 1 is preferable.